### PR TITLE
[Fix] Wrong parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Instead, you can use CSScomb as an external tool:
 1. Fill the form with following info:    
    – Name: `CSScomb`    
    – Program: `path_to_installed_csscomb/bin/csscomb`    
-   – Parameters: `-t $FilePath$`    
+   – Parameters: `$FilePath$ -t`    
    – Working directory: `$FileDir$`
 
 All checkboxes in the form are optional, you can check whichever you want.    


### PR DESCRIPTION
Tested on PyCharm 2017.4, CSScomb 4.2.0. It seems that `-t $FilePath$` won't work, but `$FilePath$ -t` works.